### PR TITLE
feat: propagate W3C trace context across the QStash boundary

### DIFF
--- a/tests/test_otel_propagation.py
+++ b/tests/test_otel_propagation.py
@@ -1,0 +1,111 @@
+"""Tests for W3C trace context propagation across the QStash boundary.
+
+When OpenTelemetry is configured, each outbound call to QStash must carry
+the current ``traceparent`` as ``Upstash-Forward-traceparent`` so QStash
+forwards it (stripped of the prefix) to the workflow destination — making
+the next step invocation a child of the current trace rather than a new
+root. Without this, multi-step workflows fragment into N disjoint root
+traces in any tracing UI (Tempo, Jaeger, Datadog, etc.).
+
+The injection is wired through ``_get_headers``, which is the single
+header-building chokepoint for every QStash publish in the library
+(initial trigger, step submissions, third-party-call steps, all of them).
+So a single integration test against ``_get_headers`` covers every
+outbound path.
+
+OpenTelemetry is a soft dependency: when it isn't installed, the
+injection helper is a no-op and the library behaves exactly as before.
+"""
+
+import pytest
+
+from upstash_workflow.workflow_requests import _get_headers, _inject_otel_context
+
+
+@pytest.fixture
+def otel_traced():
+    """Configure an in-memory OTel tracer, yield a tracer that produces
+    real traceparent values, then tear down so other tests are unaffected.
+    """
+    # Soft-import OTel so the test file can be loaded even when the
+    # opentelemetry package is unavailable (in which case the parametrize
+    # below sees zero ids and the test is skipped, matching the soft-dep
+    # contract).
+    pytest.importorskip("opentelemetry")
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    previous_provider = trace.get_tracer_provider()
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    try:
+        tracer = trace.get_tracer("test")
+        yield tracer
+    finally:
+        # Best-effort teardown — restoring an arbitrary previous provider
+        # isn't always possible (the API doesn't expose a setter for the
+        # NoOpTracerProvider), but tests don't rely on the previous state.
+        del previous_provider
+
+
+def test_get_headers_injects_traceparent_when_span_is_active(otel_traced) -> None:
+    """With an active OTel span, ``_get_headers`` writes the current
+    ``traceparent`` as ``Upstash-Forward-traceparent`` so QStash can
+    forward it to the next step destination."""
+    with otel_traced.start_as_current_span("publisher"):
+        response = _get_headers(
+            init_header_value="true",
+            workflow_run_id="wfr-test-id",
+            workflow_url="https://example.com",
+        )
+
+    assert "Upstash-Forward-traceparent" in response.headers, (
+        "Without this header, QStash delivers the next step invocation with "
+        "no parent context and the trace fragments into disjoint roots."
+    )
+    # W3C traceparent shape: ``00-<32 hex trace_id>-<16 hex span_id>-<2 hex flags>``
+    traceparent = response.headers["Upstash-Forward-traceparent"]
+    parts = traceparent.split("-")
+    assert len(parts) == 4, f"malformed traceparent: {traceparent!r}"
+    assert parts[0] == "00", "expected W3C version 00"
+    assert len(parts[1]) == 32, "expected 32-hex trace_id"
+    assert len(parts[2]) == 16, "expected 16-hex span_id"
+
+
+def test_get_headers_omits_traceparent_when_no_span_is_active(otel_traced) -> None:
+    """Without an active span, OTel's propagator writes nothing — and
+    we don't fabricate a header."""
+    response = _get_headers(
+        init_header_value="true",
+        workflow_run_id="wfr-test-id",
+        workflow_url="https://example.com",
+    )
+    assert "Upstash-Forward-traceparent" not in response.headers
+
+
+def test_inject_otel_context_is_noop_when_opentelemetry_missing(monkeypatch) -> None:
+    """The injection helper soft-imports ``opentelemetry`` so the library
+    has no runtime cost for users that don't run OTel. Simulate the
+    package being absent by making the import raise."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("opentelemetry"):
+            raise ImportError("simulated: opentelemetry not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    headers = {"X-Existing": "preserved"}
+    _inject_otel_context(headers)  # must not raise
+    assert headers == {"X-Existing": "preserved"}, (
+        "soft-dependency contract: when opentelemetry is missing, the "
+        "helper is a pure no-op and leaves the headers dict unchanged"
+    )

--- a/upstash_workflow/workflow_requests.py
+++ b/upstash_workflow/workflow_requests.py
@@ -33,6 +33,37 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
+
+def _inject_otel_context(headers: Dict[str, str]) -> None:
+    """Propagate the current OpenTelemetry context across the QStash boundary.
+
+    Each entry in the W3C trace context (``traceparent``, ``tracestate``) is
+    written as ``Upstash-Forward-<header>`` so QStash forwards it (stripped of
+    the prefix) to the workflow endpoint, where a standard HTTP instrumentor
+    can extract it as the parent context. Without this, every step delivery
+    arrives without a parent and starts a new root trace, so multi-step
+    workflows fragment into N separate disconnected traces in any tracing UI
+    (Tempo, Jaeger, Datadog, etc.).
+
+    Soft-imports ``opentelemetry``: when the package is not installed (the
+    common case for users not using OTel), this function is a no-op and the
+    library carries no runtime cost. Failures are also swallowed — a broken
+    OTel SDK must never break a workflow.
+    """
+    try:
+        from opentelemetry.propagate import inject  # type: ignore[import-not-found]
+    except ImportError:
+        return
+
+    try:
+        carrier: Dict[str, str] = {}
+        inject(carrier)
+        for key, value in carrier.items():
+            headers[f"Upstash-Forward-{key}"] = value
+    except Exception:
+        # Propagation is best-effort: never let a tracing concern break a workflow.
+        _logger.debug("OTel context injection failed", exc_info=True)
+
 TInitialPayload = TypeVar("TInitialPayload")
 
 
@@ -361,6 +392,12 @@ def _get_headers(
 
     content_type = user_headers.get("Content-Type") if user_headers else None
     content_type = DEFAULT_CONTENT_TYPE if content_type is None else content_type
+
+    # Propagate the current OTel trace context across the QStash boundary
+    # so multi-step workflows surface as one trace (rather than N disjoint
+    # root traces) in any tracing UI. No-op when OpenTelemetry is not
+    # installed; see ``_inject_otel_context`` for the rationale.
+    _inject_otel_context(base_headers)
 
     if step and step.call_headers is not None:
         forwarded_headers = {


### PR DESCRIPTION
## Problem

`workflow-py` currently does no OpenTelemetry context propagation. When a step submits the next step via QStash, no `traceparent` flows with it, so QStash invokes the next step handler with a fresh (root) trace context. Multi-step workflows therefore appear as **N disjoint root traces** in any tracing UI (Tempo, Jaeger, Datadog, etc.) — one per step invocation — instead of one trace per logical workflow run.

This breaks the standard observability pattern that every other major queue ecosystem already supports:

| Library | Native OTel context propagation |
|---|---|
| Celery | `opentelemetry-instrumentation-celery` |
| Kafka | `opentelemetry-instrumentation-kafka-python` |
| AWS SQS | `opentelemetry-instrumentation-botocore` |
| RabbitMQ | `opentelemetry-instrumentation-pika` |
| Inngest | Built in |
| **QStash / upstash-workflow** | **Not implemented** ← this PR |

I hit this in production while wiring Grafana Cloud OTel into our data-engine syncs. Each 3-step QStash workflow surfaced as 3 separate single-span "traces", which is essentially unusable for debugging a multi-step run. As a short-term workaround I'm injecting `Upstash-Forward-traceparent` from outside the library via an OTel httpx `request_hook`, but the principled fix belongs here — every workflow-py user hits the same gap.

## Fix

A single inject point in `_get_headers` — the chokepoint every QStash publish in the library already routes through (initial trigger, step submissions, third-party-call steps). The current OpenTelemetry context (`traceparent`, plus `tracestate` when present) is written as `Upstash-Forward-traceparent` (and `-tracestate`). QStash strips the `Upstash-Forward-` prefix and delivers the header to the destination, where the receiver's HTTP instrumentor (FastAPI / Flask / Django / Starlette / whatever) extracts it as the parent context.

After this PR, multi-step workflows surface as **one trace per run** in tracing UIs, with each step appearing as a child span of the previous step's outbound `POST` to QStash.

## OpenTelemetry is a soft dependency

`_inject_otel_context` soft-imports `opentelemetry.propagate.inject`. When the package is not installed (the common case for users not running OTel) the helper is a pure no-op and the library carries zero runtime cost. Failures inside the helper are caught and logged at `DEBUG` — a misconfigured tracing setup must never break a workflow.

## Diff scope

- `upstash_workflow/workflow_requests.py`: +37 lines (one helper function, one call site)
- `tests/test_otel_propagation.py`: +111 lines (three tests)
- **Zero changes** to public API, dependencies, or behaviour for non-OTel users.

Both sync (`upstash_workflow.context.auto_executor`) and async (`upstash_workflow.asyncio.context.auto_executor`) paths reuse `_get_headers` directly from `workflow_requests.py`, so a single inject point covers everything.

## Test plan

- `pytest -q` — 13 pass (10 existing + 3 new)
  - new tests verify (a) `traceparent` is injected when a span is active, (b) nothing is injected when no span is active, (c) the helper is a no-op when `opentelemetry` is unavailable
- `ruff check` — clean
- `mypy upstash_workflow/workflow_requests.py` — clean
- Local end-to-end test in a real consumer (FastAPI + ngrok + QStash, one 3-step workflow): one unified trace landed in Grafana Cloud Tempo, vs three disjoint root traces before.

## Notes / follow-ups (out of scope for this PR)

- An optional companion improvement would be wrapping each `context.run("<name>", fn)` in a `start_as_current_span(f"workflow.step.{name}")` so steps get named INTERNAL spans without users needing to decorate. Happy to do this in a separate PR if you're interested; kept it out here to minimise scope.
- Same gap exists in `upstash/workflow-js`. If you accept this, I'd be happy to mirror it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)